### PR TITLE
New configuration parameter 'tabs'

### DIFF
--- a/autoload/exconfig.vim
+++ b/autoload/exconfig.vim
@@ -88,6 +88,13 @@ function exconfig#apply()
     let &tabstop=indent_stop
     let &shiftwidth=indent_stop
 
+    let my_et = vimentry#get('tabs')
+    if my_et == "true"
+        set noexpandtab
+    elseif my_et == "false"
+        set expandtab
+    endif
+
     " Building
     let builder = vimentry#get('builder')
     let build_opt = vimentry#get('build_opt')

--- a/autoload/exconfig.vim
+++ b/autoload/exconfig.vim
@@ -88,12 +88,8 @@ function exconfig#apply()
     let &tabstop=indent_stop
     let &shiftwidth=indent_stop
 
-    let my_et = vimentry#get('tabs')
-    if my_et == "true"
-        set noexpandtab
-    elseif my_et == "false"
-        set expandtab
-    endif
+    let expand_tab = vimentry#get('expand_tab')
+    let &expandtab = (expand_tab == "true" ? 1 : 0)
 
     if exists ( ':IndentLinesReset' )
         exec 'IndentLinesReset '.indent_stop


### PR DESCRIPTION
Adds a new configuration parameter 'tabs'. `tabs = true` will use tabs only, and `tabs = false` will use spaces only.

It works by setting/unsetting `expandtab`.
