### PR TITLE
Be avoid to cover the orther tags.

### DIFF
--- a/autoload/exconfig.vim
+++ b/autoload/exconfig.vim
@@ -106,7 +106,7 @@ function exconfig#apply()
         let &tagrelative=0 " set notagrelative
 
         let s:old_tags=&tags
-        set tags+=fnameescape(g:exvim_folder.'/tags')
+        let &tags=fnameescape(s:old_tags.','.g:exvim_folder.'/tags').
 
         call exconfig#gen_sh_update_files(g:exvim_folder)
         call exconfig#gen_sh_update_ctags(g:exvim_folder)

--- a/autoload/exconfig.vim
+++ b/autoload/exconfig.vim
@@ -106,7 +106,7 @@ function exconfig#apply()
         let &tagrelative=0 " set notagrelative
 
         let s:old_tags=&tags
-        let &tags=fnameescape(g:exvim_folder.'/tags')
+        set tags+=fnameescape(g:exvim_folder.'/tags')
 
         call exconfig#gen_sh_update_files(g:exvim_folder)
         call exconfig#gen_sh_update_ctags(g:exvim_folder)

--- a/autoload/exconfig.vim
+++ b/autoload/exconfig.vim
@@ -106,7 +106,7 @@ function exconfig#apply()
         let &tagrelative=0 " set notagrelative
 
         let s:old_tags=&tags
-        let &tags=fnameescape(s:old_tags.','.g:exvim_folder.'/tags').
+        let &tags=fnameescape(s:old_tags.','.g:exvim_folder.'/tags')
 
         call exconfig#gen_sh_update_files(g:exvim_folder)
         call exconfig#gen_sh_update_ctags(g:exvim_folder)


### PR DESCRIPTION
Be avoid to cover the tags defined by user in ~/.vimrc or anywhere.