### PR TITLE
adding support for custom ctags

### DIFF
--- a/autoload/exconfig.vim
+++ b/autoload/exconfig.vim
@@ -494,17 +494,31 @@ function exconfig#gen_sh_update_ctags(path)
                     \ 'call %TOOLS%\shell\batch\update-tags.bat' ,
                     \ ]
     else
-        let fullpath = a:path . '/update-tags.sh'
-        let scripts = [
-                    \ '#!/bin/bash'                                ,
-                    \ 'export DEST="'.a:path.'"'                   ,
-                    \ 'export TOOLS="'.expand(g:ex_tools_path).'"' ,
-                    \ 'export CTAGS_CMD="'.ctags_cmd.'"'           ,
-                    \ 'export OPTIONS="'.ctags_optioins.'"'        ,
-                    \ 'export TMP="${DEST}/_tags"'                 ,
-                    \ 'export TARGET="${DEST}/tags"'               ,
-                    \ 'sh ${TOOLS}/shell/bash/update-tags.sh'      ,
-                    \ ]
+        if vimentry#check('enable_custom_tags', 'true')
+            let fullpath = a:path . '/update-tags.sh'
+            let sourcepath = vimentry#get('custom_tags_file')
+            let scripts = [
+                        \ '#!/bin/bash'                                 ,
+                        \ 'export DEST="'.a:path.'"'                    ,
+                        \ 'export TARGET="${DEST}/tags"'                ,
+                        \ 'export SOURCE="'.sourcepath.'"'              ,
+                        \ 'export TOOLS="'.expand(g:ex_tools_path).'"'  ,
+                        \ 'export CUSTOM=true'                          ,
+                        \ 'sh ${TOOLS}/shell/bash/update-tags.sh'       ,
+                        \ ]
+        else
+            let fullpath = a:path . '/update-tags.sh'
+            let scripts = [
+                        \ '#!/bin/bash'                                ,
+                        \ 'export DEST="'.a:path.'"'                   ,
+                        \ 'export TOOLS="'.expand(g:ex_tools_path).'"' ,
+                        \ 'export CTAGS_CMD="'.ctags_cmd.'"'           ,
+                        \ 'export OPTIONS="'.ctags_optioins.'"'        ,
+                        \ 'export TMP="${DEST}/_tags"'                 ,
+                        \ 'export TARGET="${DEST}/tags"'               ,
+                        \ 'sh ${TOOLS}/shell/bash/update-tags.sh'      ,
+                        \ ]
+        endif
     endif
 
     " save to file


### PR DESCRIPTION
I added a support for custom ctags. I work on LibreOffice and some of the ctags created with exuberant-ctags are too long for the tags plugin in exVim. LibreOffice does have a custom "make tags" command which creates a correct tags file. This config options allows users to use custom created tags files if they want to (pull request in the other projects added as well).